### PR TITLE
fixed java.pol path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There is an overview of the Framework's functionality available in [NotesIn9 158
 Dependencies
 ------------
 
-The Framework requires Domino 9.0.1+ and the OpenNTF Domino API 2.0.0+. Additionally, to use the model framework, the plugin must be given access to reflection via Java policy. The quickest (and time-tested) method to do this is to create a file named `java.pol` in your `jvm/lib/ext` directory in your Domino installation with the following contents:
+The Framework requires Domino 9.0.1+ and the OpenNTF Domino API 2.0.0+. Additionally, to use the model framework, the plugin must be given access to reflection via Java policy. The quickest (and time-tested) method to do this is to create a file named `java.pol` in your `jvm/lib/security` directory in your Domino installation with the following contents:
 
     grant {
             permission java.security.AllPermission;


### PR DESCRIPTION
Can it even work from .../jvm/lib/ext?

Per [John Dalsgaard's post on the subject](http://www.dalsgaard-data.eu/blog/java-security-in-ibm-domino/), I've always (successfully) only put java.pol in .../jvm/lib/security/.
